### PR TITLE
Fix loss_weight mismatch

### DIFF
--- a/EmoTrain.py
+++ b/EmoTrain.py
@@ -109,8 +109,14 @@ def comput_class_loss(log_prob, target, weights):
 def loss_weight(tr_ladict, ladict, focus_dict, rate=1.0):
 	""" Loss weights """
 	min_emo = float(min([tr_ladict.word2count[w] for w in focus_dict]))
-	weight = [math.pow(min_emo / tr_ladict.word2count[k], rate) if k in focus_dict
-	          else 0 for k,v in ladict.word2count.items()]
+	
+	weight = [0] * len(ladict.word2count.keys())
+	for k, v in ladict.word2count.items():
+		if k in focus_dict:
+			weight[ladict.word2index[k]] = math.pow(min_emo / tr_ladict.word2count[k], rate)
+		else:
+			weight[ladict.word2index[k]] = 0
+	
 	weight = np.array(weight)
 	weight /= np.sum(weight)
 


### PR DESCRIPTION
Thanks for your sharing!

At first I failed to reproduce the performance of the paper.
So I checked the code and found that the `index of label` and `index of weight` did not match.

```python
# Incorrect weight assignment because the order of ladict.word2count.items() does not match the index of the label
weight = [math.pow(min_emo / tr_ladict.word2count[k], rate) if k in focus_dict	
	          else 0 for k,v in ladict.word2count.items()]
```

I fixed the code as shown below, and succeeded in reproducing the performance of the paper.
```python
weight = [0] * len(ladict.word2count.keys())
for k, v in ladict.word2count.items():
	if k in focus_dict:
		weight[ladict.word2index[k]] = math.pow(min_emo / tr_ladict.word2count[k], rate)
	else:
		weight[ladict.word2index[k]] = 0
```